### PR TITLE
Customize DataTable

### DIFF
--- a/src/MUIDataTable.js
+++ b/src/MUIDataTable.js
@@ -1,6 +1,8 @@
 import Paper from '@material-ui/core/Paper';
 import { withStyles } from '@material-ui/core/styles';
 import MuiTable from '@material-ui/core/Table';
+import Grid from '@material-ui/core/Grid';
+import Typography from '@material-ui/core/Typography';
 import classnames from 'classnames';
 import assignwith from 'lodash.assignwith';
 import cloneDeep from 'lodash.clonedeep';
@@ -64,6 +66,22 @@ const defaultTableStyles = theme => ({
     padding: '0',
     position: 'absolute',
     width: '1px',
+  },
+  tableTitleWrapper: {
+    width: '100%',
+  },
+  tableTitleTopLine: {
+    width: '100%',
+    height: 3,
+  },
+  tableTitleContainer: {
+    padding: '2px 10px',
+    height: 56,
+  },
+  tableTitleText: {
+    marginLeft: 4,
+    fontSize: 18,
+    padding: 10,
   },
   '@global': {
     '@media print': {
@@ -197,6 +215,7 @@ class MUIDataTable extends React.Component {
     options: {},
     data: [],
     columns: [],
+    customs: {},
   };
 
   state = {
@@ -223,13 +242,14 @@ class MUIDataTable extends React.Component {
     searchText: null,
   };
 
-  constructor() {
+  constructor(props) {
     super();
     this.tableRef = false;
     this.tableContent = React.createRef();
     this.headCellRefs = {};
     this.setHeadResizeable = () => {};
     this.updateDividers = () => {};
+    this.customs = Object.assign({}, this.defaultCustom(), props.customs);
   }
 
   UNSAFE_componentWillMount() {
@@ -261,6 +281,14 @@ class MUIDataTable extends React.Component {
       this.updateDividers();
     }
   }
+
+  defaultCustom = () => ({
+    titleProps: {
+      bgColor: '#fff',
+      textColor: '#000',
+    },
+    actions: [],
+  });
 
   updateOptions(options, props) {
     this.options = assignwith(options, props.options, (objValue, srcValue, key) => {
@@ -896,7 +924,6 @@ class MUIDataTable extends React.Component {
       }),
       () => {
         this.setTableAction('changeRowsPerPage');
-
         if (this.options.onChangeRowsPerPage) {
           this.options.onChangeRowsPerPage(this.state.rowsPerPage);
         }
@@ -1250,6 +1277,7 @@ class MUIDataTable extends React.Component {
     const rowsPerPage = this.options.pagination ? this.state.rowsPerPage : displayData.length;
     const showToolbar = hasToolbarItem(this.options, title);
     const columnNames = columns.map(column => ({ name: column.name, filterType: column.filterType }));
+    const { titleProps, actions, expandText } = this.customs;
     let responsiveClass;
 
     switch (this.options.responsive) {
@@ -1273,7 +1301,7 @@ class MUIDataTable extends React.Component {
         elevation={this.options.elevation}
         ref={this.tableContent}
         className={classnames(classes.paper, className)}>
-        {selectedRows.data.length ? (
+        {/* {selectedRows.data.length ? (
           <TableToolbarSelect
             options={this.options}
             selectedRows={selectedRows}
@@ -1300,7 +1328,32 @@ class MUIDataTable extends React.Component {
               setTableAction={this.setTableAction}
             />
           )
-        )}
+        )} */}
+        <div className={classes.tableTitleWrapper} style={{ backgroundColor: titleProps.bgColor }}>
+          <div className={classes.tableTitleTopLine} style={{ backgroundColor: titleProps.textColor }} />
+          <Grid container className={classes.tableTitleContainer}>
+            <Grid container alignItems="center" item xs={9}>
+              <Typography className={classes.tableTitleText} style={{ color: titleProps.textColor }}>
+                {title}
+              </Typography>
+            </Grid>
+            {actions.length > 0 && selectedRows.data.length > 0 && (
+              <Grid container alignItems="center" item xs={3} justify={'flex-end'}>
+                {actions.map((action, index) => {
+                  const Component = action.component || 'button';
+                  const props = action.props || {};
+                  const text = action.text || 'action';
+                  const onClick = action.onClick || (() => {});
+                  return (
+                    <Component key={index} {...props} onClick={() => onClick(selectedRows)}>
+                      {text}
+                    </Component>
+                  );
+                })}
+              </Grid>
+            )}
+          </Grid>
+        </div>
         <TableFilterList
           options={this.options}
           serverSideFilterList={this.props.options.serverSideFilterList || []}
@@ -1348,6 +1401,8 @@ class MUIDataTable extends React.Component {
               toggleExpandRow={this.toggleExpandRow}
               options={this.options}
               filterList={filterList}
+              expandText={expandText}
+              noDataIndicator={this.options.noDataIndicator}
             />
           </MuiTable>
         </div>

--- a/src/components/TableBody.js
+++ b/src/components/TableBody.js
@@ -5,6 +5,7 @@ import MuiTableBody from '@material-ui/core/TableBody';
 import TableBodyCell from './TableBodyCell';
 import TableBodyRow from './TableBodyRow';
 import TableSelectCell from './TableSelectCell';
+import TableExpandCell from './TableExpandCell';
 import { withStyles } from '@material-ui/core/styles';
 import cloneDeep from 'lodash.clonedeep';
 import { getPageValue } from '../utils';
@@ -205,9 +206,12 @@ class TableBody extends React.Component {
   };
 
   render() {
-    const { classes, columns, toggleExpandRow, options } = this.props;
+    const { classes, columns, toggleExpandRow, options, expandText, noDataIndicator } = this.props;
     const tableRows = this.buildRows();
     const visibleColCnt = columns.filter(c => c.display === 'true').length;
+    let columnCount = visibleColCnt;
+    if (options.selectableRows !== 'none') columnCount += 1;
+    if (options.expandableRows) columnCount += 1;
 
     return (
       <MuiTableBody>
@@ -233,15 +237,9 @@ class TableBody extends React.Component {
                       index: this.getRowIndex(rowIndex),
                       dataIndex: dataIndex,
                     })}
-                    onExpand={toggleExpandRow.bind(null, {
-                      index: this.getRowIndex(rowIndex),
-                      dataIndex: dataIndex,
-                    })}
                     fixedHeader={options.fixedHeader}
                     checked={this.isRowSelected(dataIndex)}
-                    expandableOn={options.expandableRows}
                     selectableOn={options.selectableRows}
-                    isRowExpanded={this.isRowExpanded(dataIndex)}
                     isRowSelectable={this.isRowSelectable(dataIndex)}
                     id={'MUIDataTableSelectCell-' + dataIndex}
                   />
@@ -259,25 +257,39 @@ class TableBody extends React.Component {
                           columnHeader={columns[columnIndex].label}
                           print={columns[columnIndex].print}
                           options={options}
-                          key={columnIndex}>
+                          bodyStyles={columns[columnIndex].bodyStyles || {}}
+                          key={columnIndex}
+                        >
                           {column}
                         </TableBodyCell>
                       ),
                   )}
+                  <TableExpandCell
+                    onExpand={toggleExpandRow.bind(null, {
+                      index: this.getRowIndex(rowIndex),
+                      dataIndex: dataIndex,
+                    })}
+                    fixedHeader={options.fixedHeader}
+                    expandableOn={options.expandableRows}
+                    isRowExpanded={this.isRowExpanded(dataIndex)}
+                    isRowExpandable={this.isRowExpandable(dataIndex)}
+                    id={'MUIDataTableExpandCell-' + dataIndex}
+                    expandText={expandText}
+                  />
                 </TableBodyRow>
-                {this.isRowExpanded(dataIndex) && options.renderExpandableRow(row, { rowIndex, dataIndex })}
+                {this.isRowExpanded(dataIndex) && options.renderExpandableRow(row, { rowIndex, dataIndex }, columnCount)}
               </React.Fragment>
             );
           })
         ) : (
           <TableBodyRow options={options}>
             <TableBodyCell
-              colSpan={options.selectableRows !== 'none' || options.expandableRows ? visibleColCnt + 1 : visibleColCnt}
+              colSpan={columnCount}
               options={options}
               colIndex={0}
               rowIndex={0}>
               <Typography variant="subtitle1" className={classes.emptyTitle}>
-                {options.textLabels.body.noMatch}
+                {noDataIndicator || options.textLabels.body.noMatch}
               </Typography>
             </TableBodyCell>
           </TableBodyRow>

--- a/src/components/TableBodyCell.js
+++ b/src/components/TableBodyCell.js
@@ -47,6 +47,7 @@ class TableBodyCell extends React.Component {
       rowIndex,
       className,
       print,
+      bodyStyles,
       ...otherProps
     } = this.props;
 
@@ -75,6 +76,7 @@ class TableBodyCell extends React.Component {
           },
           className,
         )}
+        style={{...bodyStyles}}
         {...otherProps}>
         {children}
       </TableCell>,

--- a/src/components/TableExpandCell.js
+++ b/src/components/TableExpandCell.js
@@ -1,0 +1,116 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import classNames from 'classnames';
+import TableCell from '@material-ui/core/TableCell';
+import Typography from '@material-ui/core/Typography';
+import Button from '@material-ui/core/Button';
+import { withStyles } from '@material-ui/core/styles';
+import KeyboardArrowRight from '@material-ui/icons/KeyboardArrowRight';
+
+const defaultExpandCellStyles = theme => ({
+  root: {
+    width: 140,
+  },
+  fixedHeader: {
+    position: 'sticky',
+    top: '0px',
+    left: '0px',
+    zIndex: 100,
+  },
+  icon: {
+    cursor: 'pointer',
+    transition: 'transform 0.25s',
+    fontSize: 18,
+    marginLeft: 2,
+  },
+  expanded: {
+    transform: 'rotate(90deg)',
+  },
+  hide: {
+    visibility: 'hidden',
+  },
+  headerCell: {
+    zIndex: 110,
+    backgroundColor: theme.palette.background.paper,
+  },
+  checkboxRoot: {},
+  disabled: {},
+  expandContainer: {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'flex-end',
+    marginRight: 5,
+  },
+  expandButton: {
+    backgroundColor: 'transparent',
+    '&:hover': {
+      backgroundColor: 'transparent',
+    },
+  },
+  expandText: {
+    fontSize: 13,
+    textTransform: 'none',
+  },
+});
+
+class TableExpandCell extends React.Component {
+  static propTypes = {
+    /** Select cell part of fixed header */
+    fixedHeader: PropTypes.bool.isRequired,
+    /** Extend the style applied to components */
+    classes: PropTypes.object,
+    /** Is expandable option enabled */
+    expandableOn: PropTypes.bool,
+  };
+
+  static defaultProps = {
+    isHeaderCell: false,
+    isRowExpanded: false,
+    expandableOn: false,
+    expandText: 'Expand',
+  };
+
+  render() {
+    const {
+      classes,
+      fixedHeader,
+      isHeaderCell,
+      expandableOn,
+      isRowExpanded,
+      isRowExpandable,
+      onExpand,
+      expandText,
+    } = this.props;
+
+    if (!expandableOn) return false;
+
+    const cellClass = classNames({
+      [classes.root]: true,
+      [classes.fixedHeader]: fixedHeader,
+      [classes.headerCell]: isHeaderCell,
+    });
+
+    const iconClass = classNames({
+      [classes.icon]: true,
+      [classes.hide]: isHeaderCell,
+      [classes.expanded]: isRowExpanded,
+    });
+
+    return (
+      <TableCell className={cellClass} padding="checkbox">
+        <div className={classes.expandContainer}>
+          {expandableOn && !isHeaderCell && isRowExpandable && (
+            <Button className={classes.expandButton} disableRipple onClick={onExpand} disabled={isHeaderCell}>
+              <Typography component="span" className={classes.expandText}>
+                {expandText}
+              </Typography>
+              <KeyboardArrowRight id="expandable-button" size="small" className={iconClass} />
+            </Button>
+          )}
+        </div>
+      </TableCell>
+    );
+  }
+}
+
+export default withStyles(defaultExpandCellStyles, { name: 'MUIDataTableExpandCell' })(TableExpandCell);

--- a/src/components/TableHead.js
+++ b/src/components/TableHead.js
@@ -6,6 +6,7 @@ import { findDOMNode } from 'react-dom';
 import TableHeadCell from './TableHeadCell';
 import TableHeadRow from './TableHeadRow';
 import TableSelectCell from './TableSelectCell';
+import TableExpandCell from './TableExpandCell';
 
 const defaultHeadStyles = theme => ({
   main: {},
@@ -46,7 +47,6 @@ class TableHead extends React.Component {
             indeterminate={isDeterminate}
             checked={isChecked}
             isHeaderCell={true}
-            expandableOn={options.expandableRows}
             selectableOn={options.selectableRows}
             fixedHeader={options.fixedHeader}
             selectableRowsHeader={options.selectableRowsHeader}
@@ -69,11 +69,18 @@ class TableHead extends React.Component {
                   hint={column.hint}
                   print={column.print}
                   options={options}
-                  column={column}>
+                  column={column}
+                  headStyles={column.headStyles || {}}
+                >
                   {column.label}
                 </TableHeadCell>
               )),
           )}
+          <TableExpandCell
+            isHeaderCell={true}
+            expandableOn={options.expandableRows}
+            fixedHeader={options.fixedHeader}
+          />
         </TableHeadRow>
       </MuiTableHead>
     );

--- a/src/components/TableHeadCell.js
+++ b/src/components/TableHeadCell.js
@@ -91,7 +91,7 @@ class TableHeadCell extends React.Component {
 
   render() {
     const { isSortTooltipOpen, isHintTooltipOpen } = this.state;
-    const { children, classes, options, sortDirection, sort, hint, print, column } = this.props;
+    const { children, classes, options, sortDirection, sort, hint, print, column, headStyles } = this.props;
     const sortActive = sortDirection !== 'none' && sortDirection !== undefined ? true : false;
     const ariaSortDirection = sortDirection === 'none' ? false : sortDirection;
 
@@ -109,7 +109,7 @@ class TableHeadCell extends React.Component {
     });
 
     return (
-      <TableCell className={cellClass} scope={'col'} sortDirection={ariaSortDirection}>
+      <TableCell className={cellClass} scope={'col'} sortDirection={ariaSortDirection} style={{...headStyles}}>
         {options.sort && sort ? (
           <Tooltip
             title={

--- a/src/components/TableSelectCell.js
+++ b/src/components/TableSelectCell.js
@@ -3,9 +3,7 @@ import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import Checkbox from '@material-ui/core/Checkbox';
 import TableCell from '@material-ui/core/TableCell';
-import IconButton from '@material-ui/core/IconButton';
 import { withStyles } from '@material-ui/core/styles';
-import KeyboardArrowRight from '@material-ui/icons/KeyboardArrowRight';
 
 const defaultSelectCellStyles = theme => ({
   root: {},
@@ -14,13 +12,6 @@ const defaultSelectCellStyles = theme => ({
     top: '0px',
     left: '0px',
     zIndex: 100,
-  },
-  icon: {
-    cursor: 'pointer',
-    transition: 'transform 0.25s',
-  },
-  expanded: {
-    transform: 'rotate(90deg)',
   },
   hide: {
     visibility: 'hidden',
@@ -44,8 +35,6 @@ class TableSelectCell extends React.Component {
     onChange: PropTypes.func,
     /** Extend the style applied to components */
     classes: PropTypes.object,
-    /** Is expandable option enabled */
-    expandableOn: PropTypes.bool,
     /** Is selectable option enabled */
     selectableOn: PropTypes.string,
     /** Select cell disabled on/off */
@@ -53,8 +42,6 @@ class TableSelectCell extends React.Component {
 
   static defaultProps = {
     isHeaderCell: false,
-    isRowExpanded: false,
-    expandableOn: false,
     selectableOn: 'none',
   };
 
@@ -63,16 +50,13 @@ class TableSelectCell extends React.Component {
       classes,
       fixedHeader,
       isHeaderCell,
-      expandableOn,
       selectableOn,
-      isRowExpanded,
-      onExpand,
       isRowSelectable,
       selectableRowsHeader,
       ...otherProps
     } = this.props;
 
-    if (!expandableOn && selectableOn === 'none') return false;
+    if (selectableOn === 'none') return false;
 
     const cellClass = classNames({
       [classes.root]: true,
@@ -80,15 +64,13 @@ class TableSelectCell extends React.Component {
       [classes.headerCell]: isHeaderCell,
     });
 
-    const iconClass = classNames({
-      [classes.icon]: true,
-      [classes.hide]: isHeaderCell,
-      [classes.expanded]: isRowExpanded,
-    });
-
     const renderCheckBox = () => {
       if (isHeaderCell && (selectableOn !== 'multiple' || selectableRowsHeader === false)) {
         // only display the header checkbox for multiple selection.
+        return null;
+      }
+      if (!isRowSelectable) {
+        // Also hide select cell if the row is not selectable
         return null;
       }
       return (
@@ -107,14 +89,7 @@ class TableSelectCell extends React.Component {
 
     return (
       <TableCell className={cellClass} padding="checkbox">
-        <div style={{ display: 'flex', alignItems: 'center' }}>
-          {expandableOn && (
-            <IconButton onClick={onExpand} disabled={isHeaderCell}>
-              <KeyboardArrowRight id="expandable-button" className={iconClass} />
-            </IconButton>
-          )}
-          {selectableOn !== 'none' && renderCheckBox()}
-        </div>
+        <div style={{ display: 'flex', alignItems: 'center' }}>{selectableOn !== 'none' && renderCheckBox()}</div>
       </TableCell>
     );
   }


### PR DESCRIPTION
Temporary disable table toolbar
Add customs props to MUIDataTable
Separate Table Select and Expand Cell
Hide cell when it's not selectable/expandable
Add noDataIndicator options
Add headStyles and bodyStyles